### PR TITLE
General Fixes & Types

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -120,7 +120,7 @@ None.
 
 | Prop name  | Kind             | Reactive | Type                | Default value         | Description |
 | :--------- | :--------------- | :------- | :------------------ | --------------------- | ----------- |
-| id         | <code>let</code> | No       | --                  | --                    | --          |
+| id         | <code>let</code> | No       | <code>string</code> | --                    | --          |
 | filters    | <code>let</code> | No       | <code>[]</code>     | <code>[]</code>       | --          |
 | offset     | <code>let</code> | No       | <code>number</code> | <code>0</code>        | --          |
 | limit      | <code>let</code> | No       | <code>number</code> | <code>25</code>       | --          |
@@ -131,11 +131,11 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                    | Fallback |
-| :-------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ documents: any; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                          | --       |
-| loading   | No      | --                                                                                                                                                       | --       |
+| Slot name | Default | Props                                                                                                                                                                  | Fallback |
+| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ id: string; documents: any[]; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                        | --       |
+| loading   | No      | --                                                                                                                                                                     | --       |
 
 ### Events
 
@@ -239,19 +239,19 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type | Default value | Description |
-| :--------- | :--------------- | :------- | :--- | ------------- | ----------- |
-| document   | <code>let</code> | Yes      | --   | --            | --          |
-| collection | <code>let</code> | Yes      | --   | --            | --          |
-| id         | <code>let</code> | Yes      | --   | --            | --          |
+| Prop name  | Kind             | Reactive | Type                | Default value | Description |
+| :--------- | :--------------- | :------- | :------------------ | ------------- | ----------- |
+| document   | <code>let</code> | Yes      | <code>any</code>    | --            | --          |
+| collection | <code>let</code> | Yes      | <code>string</code> | --            | --          |
+| id         | <code>let</code> | Yes      | <code>string</code> | --            | --          |
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                | Fallback |
-| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ documents: any; actions: { reload: () => Promise<object>; update: (data: any) => Promise<object>; remove: () => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: any } </code>                                                                                                                         | --       |
-| loading   | No      | --                                                                                                                                                   | --       |
+| Slot name | Default | Props                                                                                                                                               | Fallback |
+| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ document: any; actions: { reload: () => Promise<object>; update: (data: any) => Promise<object>; remove: () => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: any } </code>                                                                                                                        | --       |
+| loading   | No      | --                                                                                                                                                  | --       |
 
 ### Events
 
@@ -287,10 +287,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                                                                                                                                                   | Fallback |
-| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ actions: { download: () => string; view: (as?: string) => string; preview: (width?: string, height?: string, quality?: string, background?: string, output?: string) => string; update: (read?: any, write?: any) => Promise<object>; delete: () => Promise<object>; }} </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                                                                                                                                                         | --       |
+| Slot name | Default | Props                                                                                                                                                                                                                                                                                              | Fallback |
+| :-------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ file: any; actions: { download: () => string; view: (as?: string) => string; preview: (width?: string, height?: string, quality?: string, background?: string, output?: string) => string; update: (read?: any, write?: any) => Promise<object>; delete: () => Promise<object>; }} </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                                                                                                                                                    | --       |
 
 ### Events
 
@@ -309,11 +309,11 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                    | Fallback |
-| :-------- | :------ | :----------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ files: any; actions: { reload: () => Promise<object>; }} </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                          | --       |
-| loading   | No      | --                                                                       | --       |
+| Slot name | Default | Props                                                                      | Fallback |
+| :-------- | :------ | :------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ files: any[]; actions: { reload: () => Promise<object>; }} </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                            | --       |
+| loading   | No      | --                                                                         | --       |
 
 ### Events
 
@@ -514,17 +514,31 @@ None.
 
 ## `User`
 
+### Types
+
+```ts
+export interface AppwriteUser {
+  $id: string;
+  email: string;
+  emailVerification: boolean;
+  name: string;
+  registration: number;
+  status: number;
+  prefs: object;
+}
+```
+
 ### Props
 
 None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                                 | Fallback |
-| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ actions: { reload: () => void; logout: () => Promise<object>; logoutFrom: (session: string) => Promise<object>; logoutAll: () => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                                       | --       |
-| loading   | No      | --                                                                                                                                                                    | --       |
+| Slot name | Default | Props                                                                                                                                                                                     | Fallback |
+| :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ user: AppwriteUser; actions: { reload: () => void; logout: () => Promise<object>; logoutFrom: (session: string) => Promise<object>; logoutAll: () => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                                           | --       |
+| loading   | No      | --                                                                                                                                                                                        | --       |
 
 ### Events
 

--- a/src/Account/User.svelte
+++ b/src/Account/User.svelte
@@ -1,7 +1,19 @@
 <script>
   /**
+   * @typedef {{
+   * $id: string, 
+   * email: string, 
+   * emailVerification: boolean, 
+   * name: string, 
+   * registration: number, 
+   * status: number, 
+   * prefs: object 
+   * }} AppwriteUser
+   */
+
+  /**
    * @slot {{
-   * user: any;
+   * user: AppwriteUser;
    * actions: {
    *  reload: () => void;
    *  logout: () => Promise<object>;

--- a/src/Database/Collection.svelte
+++ b/src/Database/Collection.svelte
@@ -1,7 +1,8 @@
 <script>
   /**
    * @slot {{
-   * documents: any;
+   * id: string;
+   * documents: any[];
    * actions: {
    *  reload: () => Promise<object>;
    *  create: (data: any, read?: string[], write?: string[]) => Promise<object>;
@@ -12,6 +13,11 @@
   import { SDK as Appwrite }  from "../appwrite";
   import { currentUser } from "../stores";
 
+  
+  /**
+   * @name Collection ID
+   * @type {string}
+   */
   export let id;
   export let filters = [];
   export let offset = 0;
@@ -25,8 +31,8 @@
     Appwrite.sdk.database.listDocuments(
       id,
       filters,
-      offset,
       limit,
+      offset,
       orderField,
       orderType,
       orderCast,

--- a/src/Database/Document.svelte
+++ b/src/Database/Document.svelte
@@ -1,7 +1,7 @@
-<script>
+<script>  
   /**
    * @slot {{
-   * documents: any;
+   * document: any;
    * actions: {
    *  reload: () => Promise<object>;
    *  update: (data: any) => Promise<object>;
@@ -13,8 +13,22 @@
   import { SDK as Appwrite }  from "../appwrite";
 
   const dispatch = createEventDispatcher();
+  /**
+   * @name Document ID
+   * @type {string}
+   */
   export let id;
+
+  /**
+   * @name Collection ID
+   * @type {string}
+   */
   export let collection;
+
+  /**
+   * @name Document Object
+   * @type {any}
+   */
   export let document;
 
   const fetchDocument = () => Appwrite.sdk.database.getDocument(collection, id);

--- a/src/Storage/File.svelte
+++ b/src/Storage/File.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
    * @slot {{
+   * file: any;
    * actions: {
    *  download: () => string;
    *  view: (as?: string) => string;

--- a/src/Storage/FileList.svelte
+++ b/src/Storage/FileList.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @slot {{
-   * files: any;
+   * files: any[];
    * actions: {
    *   reload: () => Promise<object>;
    * }}}

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store";
-import { userStore } from "./stores/user";
+import { UserStore } from "./Stores/user";
 
 export const active = writable(false);
-
-export const currentUser = userStore(false);
+export const currentUser = new UserStore();

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -15,17 +15,17 @@ export class UserStore {
    */
   async reload() {
     const response = await Appwrite.sdk.account.get();
-    set(response);
+    this.set(response);
     return response;
   }
 
   /**
-   *  Logout the current User.
+   * Logout the current User.
    * @returns {object}
    */
   async logout() {
     const response = await Appwrite.sdk.account.deleteSession("current");
-    set(false);
+    this.set(null);
     return response;
   }
 }

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,23 +1,32 @@
 import { SDK as Appwrite }  from "../appwrite";
 import { writable } from "svelte/store";
 
-export const userStore = (value) => {
-  const { subscribe, set, update } = writable(value);
+export class UserStore {
+  constructor() {
+    const { subscribe, set, update } = writable(null);
+    this.subscribe = subscribe;
+    this.set = set;
+    this.update = update;
+  }
 
-  return {
-    subscribe,
-    set,
-    update,
+  /**
+   * Reload the current User.
+   * @returns {object}
+   */
+  async reload() {
+    const response = await Appwrite.sdk.account.get();
+    set(response);
+    return response;
+  }
 
-    reload: async () => {
-      const response = await Appwrite.sdk.account.get();
-      set(response);
-      return response;
-    },
-    logout: async () => {
-      const response = await Appwrite.sdk.account.deleteSession("current");
-      set(false);
-      return response;
-    }
+  /**
+   *  Logout the current User.
+   * @returns {object}
+   */
+  async logout() {
+    const response = await Appwrite.sdk.account.deleteSession("current");
+    set(false);
+    return response;
   }
 }
+

--- a/types/Account/User.d.ts
+++ b/types/Account/User.d.ts
@@ -1,6 +1,16 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
+export interface AppwriteUser {
+  $id: string;
+  email: string;
+  emailVerification: boolean;
+  name: string;
+  registration: number;
+  status: number;
+  prefs: object;
+}
+
 export interface UserProps {}
 
 export default class User extends SvelteComponentTyped<
@@ -17,7 +27,7 @@ export default class User extends SvelteComponentTyped<
   },
   {
     default: {
-      user: any,
+      user: AppwriteUser;
       actions: {
         reload: () => void;
         logout: () => Promise<object>;

--- a/types/Database/Collection.d.ts
+++ b/types/Database/Collection.d.ts
@@ -2,7 +2,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface CollectionProps {
-  id?: undefined;
+  id?: string;
 
   /**
    * @default []
@@ -45,7 +45,8 @@ export default class Collection extends SvelteComponentTyped<
   {},
   {
     default: {
-      documents: any;
+      id: string;
+      documents: any[];
       actions: {
         reload: () => Promise<object>;
         create: (

--- a/types/Database/Document.d.ts
+++ b/types/Database/Document.d.ts
@@ -2,11 +2,11 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface DocumentProps {
-  id?: undefined;
+  id?: string;
 
-  collection?: undefined;
+  collection?: string;
 
-  document?: undefined;
+  document?: any;
 }
 
 export default class Document extends SvelteComponentTyped<
@@ -14,7 +14,7 @@ export default class Document extends SvelteComponentTyped<
   { change: CustomEvent<any> },
   {
     default: {
-      documents: any;
+      document: any;
       actions: {
         reload: () => Promise<object>;
         update: (data: any) => Promise<object>;

--- a/types/Storage/File.d.ts
+++ b/types/Storage/File.d.ts
@@ -10,6 +10,7 @@ export default class File extends SvelteComponentTyped<
   {},
   {
     default: {
+      file: any;
       actions: {
         download: () => string;
         view: (as?: string) => string;

--- a/types/Storage/FileList.d.ts
+++ b/types/Storage/FileList.d.ts
@@ -28,7 +28,7 @@ export default class FileList extends SvelteComponentTyped<
   {},
   {
     default: {
-      files: any;
+      files: any[];
       actions: {
         reload: () => Promise<object>;
       };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 export { default as Appwrite } from "./Init";
+export { default as SDK } from "./appwrite";
 export { default as User } from "./Account/User";
 export { default as Create } from "./Account/Create";
 export { default as Delete } from "./Account/Delete";


### PR DESCRIPTION
Changes
---

- Fixed `offset` and `limit` being swapped in the `listDocuments` call in the `Collection` component. (Example: Settings `limit` to `50` would send the request with `offset=50`, and vice versa)
- Added definition for `id`, and `documents` props in the `Collection` component.
- Added definition for `id`, `collection`, and  `document` props in the `Document` component.
- Added definition for the `file` prop in the `Files` component.
- Added definition for `files` prop in the `FileList` component.
- Added type for `AppwriteUser` for the `user` prop in the `User` component. 
- Updated `userStore` to a class for readability.

Reason for changes
---
I'm writing something with Svelte and TypeScript and found a bug with the `Collection` component, and noticed a few definitions were missing causing errors in VS Code.