### PR TITLE
Document Caching

### DIFF
--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -120,7 +120,7 @@ None.
 
 | Prop name  | Kind             | Reactive | Type                | Default value         | Description |
 | :--------- | :--------------- | :------- | :------------------ | --------------------- | ----------- |
-| id         | <code>let</code> | No       | --                  | --                    | --          |
+| id         | <code>let</code> | No       | <code>string</code> | --                    | --          |
 | filters    | <code>let</code> | No       | <code>[]</code>     | <code>[]</code>       | --          |
 | offset     | <code>let</code> | No       | <code>number</code> | <code>0</code>        | --          |
 | limit      | <code>let</code> | No       | <code>number</code> | <code>25</code>       | --          |
@@ -131,11 +131,11 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                    | Fallback |
-| :-------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ documents: any; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                          | --       |
-| loading   | No      | --                                                                                                                                                       | --       |
+| Slot name | Default | Props                                                                                                                                                                  | Fallback |
+| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ id: string; documents: any[]; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                        | --       |
+| loading   | No      | --                                                                                                                                                                     | --       |
 
 ### Events
 
@@ -239,19 +239,19 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type | Default value | Description |
-| :--------- | :--------------- | :------- | :--- | ------------- | ----------- |
-| document   | <code>let</code> | Yes      | --   | --            | --          |
-| collection | <code>let</code> | Yes      | --   | --            | --          |
-| id         | <code>let</code> | Yes      | --   | --            | --          |
+| Prop name  | Kind             | Reactive | Type                | Default value | Description |
+| :--------- | :--------------- | :------- | :------------------ | ------------- | ----------- |
+| document   | <code>let</code> | Yes      | <code>any</code>    | --            | --          |
+| collection | <code>let</code> | Yes      | <code>string</code> | --            | --          |
+| id         | <code>let</code> | Yes      | <code>string</code> | --            | --          |
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                | Fallback |
-| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ documents: any; actions: { reload: () => Promise<object>; update: (data: any) => Promise<object>; remove: () => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: any } </code>                                                                                                                         | --       |
-| loading   | No      | --                                                                                                                                                   | --       |
+| Slot name | Default | Props                                                                                                                                               | Fallback |
+| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ document: any; actions: { reload: () => Promise<object>; update: (data: any) => Promise<object>; remove: () => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: any } </code>                                                                                                                        | --       |
+| loading   | No      | --                                                                                                                                                  | --       |
 
 ### Events
 
@@ -287,10 +287,10 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                                                                                                                                                   | Fallback |
-| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ actions: { download: () => string; view: (as?: string) => string; preview: (width?: string, height?: string, quality?: string, background?: string, output?: string) => string; update: (read?: any, write?: any) => Promise<object>; delete: () => Promise<object>; }} </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                                                                                                                                                         | --       |
+| Slot name | Default | Props                                                                                                                                                                                                                                                                                              | Fallback |
+| :-------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ file: any; actions: { download: () => string; view: (as?: string) => string; preview: (width?: string, height?: string, quality?: string, background?: string, output?: string) => string; update: (read?: any, write?: any) => Promise<object>; delete: () => Promise<object>; }} </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                                                                                                                                                    | --       |
 
 ### Events
 
@@ -309,11 +309,11 @@ None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                    | Fallback |
-| :-------- | :------ | :----------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ files: any; actions: { reload: () => Promise<object>; }} </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                          | --       |
-| loading   | No      | --                                                                       | --       |
+| Slot name | Default | Props                                                                      | Fallback |
+| :-------- | :------ | :------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ files: any[]; actions: { reload: () => Promise<object>; }} </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                            | --       |
+| loading   | No      | --                                                                         | --       |
 
 ### Events
 
@@ -514,17 +514,31 @@ None.
 
 ## `User`
 
+### Types
+
+```ts
+export interface AppwriteUser {
+  $id: string;
+  email: string;
+  emailVerification: boolean;
+  name: string;
+  registration: number;
+  status: number;
+  prefs: object;
+}
+```
+
 ### Props
 
 None.
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                                 | Fallback |
-| :-------- | :------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ actions: { reload: () => void; logout: () => Promise<object>; logoutFrom: (session: string) => Promise<object>; logoutAll: () => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                                       | --       |
-| loading   | No      | --                                                                                                                                                                    | --       |
+| Slot name | Default | Props                                                                                                                                                                                     | Fallback |
+| :-------- | :------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ user: AppwriteUser; actions: { reload: () => void; logout: () => Promise<object>; logoutFrom: (session: string) => Promise<object>; logoutAll: () => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                                                           | --       |
+| loading   | No      | --                                                                                                                                                                                        | --       |
 
 ### Events
 

--- a/COMPONENT_INDEX.md
+++ b/COMPONENT_INDEX.md
@@ -118,24 +118,25 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                | Default value         | Description |
-| :--------- | :--------------- | :------- | :------------------ | --------------------- | ----------- |
-| id         | <code>let</code> | No       | <code>string</code> | --                    | --          |
-| filters    | <code>let</code> | No       | <code>[]</code>     | <code>[]</code>       | --          |
-| offset     | <code>let</code> | No       | <code>number</code> | <code>0</code>        | --          |
-| limit      | <code>let</code> | No       | <code>number</code> | <code>25</code>       | --          |
-| orderField | <code>let</code> | No       | <code>string</code> | <code>""</code>       | --          |
-| orderType  | <code>let</code> | No       | <code>string</code> | <code>""</code>       | --          |
-| orderCast  | <code>let</code> | No       | <code>string</code> | <code>"string"</code> | --          |
-| search     | <code>let</code> | No       | <code>string</code> | <code>""</code>       | --          |
+| Prop name  | Kind             | Reactive | Type                  | Default value         | Description |
+| :--------- | :--------------- | :------- | :-------------------- | --------------------- | ----------- |
+| id         | <code>let</code> | No       | <code>string</code>   | --                    | --          |
+| filters    | <code>let</code> | No       | <code>string[]</code> | <code>[]</code>       | --          |
+| offset     | <code>let</code> | No       | <code>number</code>   | <code>0</code>        | --          |
+| limit      | <code>let</code> | No       | <code>number</code>   | <code>25</code>       | --          |
+| orderField | <code>let</code> | No       | <code>string</code>   | <code>''</code>       | --          |
+| orderType  | <code>let</code> | No       | <code>string</code>   | <code>''</code>       | --          |
+| orderCast  | <code>let</code> | No       | <code>string</code>   | <code>'string'</code> | --          |
+| search     | <code>let</code> | No       | <code>string</code>   | <code>''</code>       | --          |
+| cache      | <code>let</code> | No       | <code>boolean</code>  | <code>false</code>    | --          |
 
 ### Slots
 
-| Slot name | Default | Props                                                                                                                                                                  | Fallback |
-| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
-| --        | Yes     | <code>{ id: string; documents: any[]; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
-| error     | No      | <code>{ error: object } </code>                                                                                                                                        | --       |
-| loading   | No      | --                                                                                                                                                                     | --       |
+| Slot name | Default | Props                                                                                                                                                      | Fallback |
+| :-------- | :------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| --        | Yes     | <code>{ documents: any[]; actions: { reload: () => Promise<object>; create: (data: any, read?: string[], write?: string[]) => Promise<object>; } } </code> | --       |
+| error     | No      | <code>{ error: object } </code>                                                                                                                            | --       |
+| loading   | No      | --                                                                                                                                                         | --       |
 
 ### Events
 
@@ -239,11 +240,12 @@ None.
 
 ### Props
 
-| Prop name  | Kind             | Reactive | Type                | Default value | Description |
-| :--------- | :--------------- | :------- | :------------------ | ------------- | ----------- |
-| document   | <code>let</code> | Yes      | <code>any</code>    | --            | --          |
-| collection | <code>let</code> | Yes      | <code>string</code> | --            | --          |
-| id         | <code>let</code> | Yes      | <code>string</code> | --            | --          |
+| Prop name  | Kind             | Reactive | Type                 | Default value | Description |
+| :--------- | :--------------- | :------- | :------------------- | ------------- | ----------- |
+| document   | <code>let</code> | Yes      | <code>any</code>     | --            | --          |
+| collection | <code>let</code> | Yes      | <code>string</code>  | --            | --          |
+| id         | <code>let</code> | Yes      | <code>string</code>  | --            | --          |
+| cache      | <code>let</code> | No       | <code>boolean</code> | --            | --          |
 
 ### Slots
 

--- a/src/Account/User.svelte
+++ b/src/Account/User.svelte
@@ -1,7 +1,19 @@
 <script>
   /**
+   * @typedef {{
+   * $id: string, 
+   * email: string, 
+   * emailVerification: boolean, 
+   * name: string, 
+   * registration: number, 
+   * status: number, 
+   * prefs: object 
+   * }} AppwriteUser
+   */
+
+  /**
    * @slot {{
-   * user: any;
+   * user: AppwriteUser;
    * actions: {
    *  reload: () => void;
    *  logout: () => Promise<object>;

--- a/src/Database/Collection.svelte
+++ b/src/Database/Collection.svelte
@@ -1,7 +1,8 @@
 <script>
   /**
    * @slot {{
-   * documents: any;
+   * id: string;
+   * documents: any[];
    * actions: {
    *  reload: () => Promise<object>;
    *  create: (data: any, read?: string[], write?: string[]) => Promise<object>;
@@ -12,6 +13,11 @@
   import { SDK as Appwrite }  from "../appwrite";
   import { currentUser } from "../stores";
 
+  
+  /**
+   * @name Collection ID
+   * @type {string}
+   */
   export let id;
   export let filters = [];
   export let offset = 0;
@@ -25,8 +31,8 @@
     Appwrite.sdk.database.listDocuments(
       id,
       filters,
-      offset,
       limit,
+      offset,
       orderField,
       orderType,
       orderCast,

--- a/src/Database/Document.svelte
+++ b/src/Database/Document.svelte
@@ -41,8 +41,10 @@
   export let cache = getContext(cacheKey) ?? false;
 
   const fetchDocument = async () => {
-    return await documents.fetchDocument(collection, id, cache);
-  };
+    const response = await documents.fetchDocument(collection, id, cache)
+    document = response;
+    return response;
+  }
 
   if (id && collection && !document) {
     document = fetchDocument();

--- a/src/Database/Document.svelte
+++ b/src/Database/Document.svelte
@@ -1,7 +1,7 @@
-<script>
+<script>  
   /**
    * @slot {{
-   * documents: any;
+   * document: any;
    * actions: {
    *  reload: () => Promise<object>;
    *  update: (data: any) => Promise<object>;
@@ -13,8 +13,22 @@
   import { SDK as Appwrite }  from "../appwrite";
 
   const dispatch = createEventDispatcher();
+  /**
+   * @name Document ID
+   * @type {string}
+   */
   export let id;
+
+  /**
+   * @name Collection ID
+   * @type {string}
+   */
   export let collection;
+
+  /**
+   * @name Document Object
+   * @type {any}
+   */
   export let document;
 
   const fetchDocument = () => Appwrite.sdk.database.getDocument(collection, id);

--- a/src/Storage/File.svelte
+++ b/src/Storage/File.svelte
@@ -1,6 +1,7 @@
 <script>
   /**
    * @slot {{
+   * file: any;
    * actions: {
    *  download: () => string;
    *  view: (as?: string) => string;

--- a/src/Storage/FileList.svelte
+++ b/src/Storage/FileList.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * @slot {{
-   * files: any;
+   * files: any[];
    * actions: {
    *   reload: () => Promise<object>;
    * }}}

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,0 +1,1 @@
+export const cacheKey = {};

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store";
-import { userStore } from "./stores/user";
+import { UserStore } from "./Stores/user";
 
 export const active = writable(false);
-
-export const currentUser = userStore(false);
+export const currentUser = new UserStore();

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,5 +1,7 @@
 import { writable } from "svelte/store";
 import { UserStore } from "./Stores/user";
+import { DocumentsStore } from "./Stores/documents";
 
 export const active = writable(false);
 export const currentUser = new UserStore();
+export const documents = new DocumentsStore();

--- a/src/stores/documents.js
+++ b/src/stores/documents.js
@@ -1,0 +1,85 @@
+import { SDK as Appwrite }  from "../appwrite";
+import { writable, get } from "svelte/store";
+
+export class DocumentsStore {
+  constructor() {
+    const { subscribe, set, update } = writable(new Map());
+    this.subscribe = subscribe;
+    this.set = set;
+    this.update = update;
+  }
+
+  clear() {
+    this.set(new Map());
+  }
+
+  /**
+   * Get Documents in a Collection
+   * @param {string} id Collection Id
+   * @param {boolean} cache Use cached response
+   * @param {{ filters: string[], limit: number, offset: number, orderField: string, orderType: string, orderCast: string, search: string }} query Query paramters
+   * @returns {Promise<{documents: any[], sum: number}>}
+   */
+  async fetchDocuments(id, cache, query) {
+    if (cache) {
+      const docs = Array
+        .from(get(this).entries())
+        .filter(entry => entry[0].startsWith(id))
+        .map(entry => entry[1])
+
+      if (docs?.length) {
+        return {
+          documents: docs,
+          sum: docs.length
+        }
+      }
+    }
+
+    const response = await Appwrite.sdk.database.listDocuments(
+      id,
+      query.filters,
+      query.limit,
+      query.offset,
+      query.orderField,
+      query.orderType,
+      query.orderCast,
+      query.search,
+    )
+
+    if (cache) {
+      this.update(docs => {
+        for (const document of response.documents) {
+          docs.set(`${id}:${document.$id}`, document);
+        }
+        return docs;
+      })
+    }
+    return response;
+  }
+
+  /**
+   * @param {string} collection Collection ID
+   * @param {string} id Document ID
+   * @param {boolean} cache Use cache
+   * @returns {Promise<any>}
+   */
+  async fetchDocument(collection, id, cache) {
+    const key = `${collection}:${id}`;
+    if (cache) {
+      const docs = get(this);
+      if (docs.has(key)) return docs.get(key);
+    }
+
+    const response = Appwrite.sdk.database.getDocument(collection, id)
+
+    if (cache) {
+      this.update(docs => {
+        docs.set(key, response);
+        return docs;
+      });
+    }
+  
+    return response;
+  }
+}
+

--- a/src/stores/documents.js
+++ b/src/stores/documents.js
@@ -70,7 +70,7 @@ export class DocumentsStore {
       if (docs.has(key)) return docs.get(key);
     }
 
-    const response = Appwrite.sdk.database.getDocument(collection, id)
+    const response = await Appwrite.sdk.database.getDocument(collection, id)
 
     if (cache) {
       this.update(docs => {

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -15,17 +15,17 @@ export class UserStore {
    */
   async reload() {
     const response = await Appwrite.sdk.account.get();
-    set(response);
+    this.set(response);
     return response;
   }
 
   /**
-   *  Logout the current User.
+   * Logout the current User.
    * @returns {object}
    */
   async logout() {
     const response = await Appwrite.sdk.account.deleteSession("current");
-    set(false);
+    this.set(null);
     return response;
   }
 }

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,23 +1,32 @@
 import { SDK as Appwrite }  from "../appwrite";
 import { writable } from "svelte/store";
 
-export const userStore = (value) => {
-  const { subscribe, set, update } = writable(value);
+export class UserStore {
+  constructor() {
+    const { subscribe, set, update } = writable(null);
+    this.subscribe = subscribe;
+    this.set = set;
+    this.update = update;
+  }
 
-  return {
-    subscribe,
-    set,
-    update,
+  /**
+   * Reload the current User.
+   * @returns {object}
+   */
+  async reload() {
+    const response = await Appwrite.sdk.account.get();
+    set(response);
+    return response;
+  }
 
-    reload: async () => {
-      const response = await Appwrite.sdk.account.get();
-      set(response);
-      return response;
-    },
-    logout: async () => {
-      const response = await Appwrite.sdk.account.deleteSession("current");
-      set(false);
-      return response;
-    }
+  /**
+   *  Logout the current User.
+   * @returns {object}
+   */
+  async logout() {
+    const response = await Appwrite.sdk.account.deleteSession("current");
+    set(false);
+    return response;
   }
 }
+

--- a/types/Account/User.d.ts
+++ b/types/Account/User.d.ts
@@ -1,6 +1,16 @@
 /// <reference types="svelte" />
 import { SvelteComponentTyped } from "svelte";
 
+export interface AppwriteUser {
+  $id: string;
+  email: string;
+  emailVerification: boolean;
+  name: string;
+  registration: number;
+  status: number;
+  prefs: object;
+}
+
 export interface UserProps {}
 
 export default class User extends SvelteComponentTyped<
@@ -17,7 +27,7 @@ export default class User extends SvelteComponentTyped<
   },
   {
     default: {
-      user: any,
+      user: AppwriteUser;
       actions: {
         reload: () => void;
         logout: () => Promise<object>;

--- a/types/Database/Collection.d.ts
+++ b/types/Database/Collection.d.ts
@@ -7,7 +7,7 @@ export interface CollectionProps {
   /**
    * @default []
    */
-  filters?: [];
+  filters?: string[];
 
   /**
    * @default 0
@@ -20,24 +20,29 @@ export interface CollectionProps {
   limit?: number;
 
   /**
-   * @default ""
+   * @default ''
    */
   orderField?: string;
 
   /**
-   * @default ""
+   * @default ''
    */
   orderType?: string;
 
   /**
-   * @default "string"
+   * @default 'string'
    */
   orderCast?: string;
 
   /**
-   * @default ""
+   * @default ''
    */
   search?: string;
+
+  /**
+   * @default false
+   */
+  cache?: boolean;
 }
 
 export default class Collection extends SvelteComponentTyped<
@@ -45,7 +50,6 @@ export default class Collection extends SvelteComponentTyped<
   {},
   {
     default: {
-      id: string;
       documents: any[];
       actions: {
         reload: () => Promise<object>;

--- a/types/Database/Collection.d.ts
+++ b/types/Database/Collection.d.ts
@@ -2,7 +2,7 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface CollectionProps {
-  id?: undefined;
+  id?: string;
 
   /**
    * @default []
@@ -45,7 +45,8 @@ export default class Collection extends SvelteComponentTyped<
   {},
   {
     default: {
-      documents: any;
+      id: string;
+      documents: any[];
       actions: {
         reload: () => Promise<object>;
         create: (

--- a/types/Database/Document.d.ts
+++ b/types/Database/Document.d.ts
@@ -7,6 +7,8 @@ export interface DocumentProps {
   collection?: string;
 
   document?: any;
+
+  cache?: boolean;
 }
 
 export default class Document extends SvelteComponentTyped<

--- a/types/Database/Document.d.ts
+++ b/types/Database/Document.d.ts
@@ -2,11 +2,11 @@
 import { SvelteComponentTyped } from "svelte";
 
 export interface DocumentProps {
-  id?: undefined;
+  id?: string;
 
-  collection?: undefined;
+  collection?: string;
 
-  document?: undefined;
+  document?: any;
 }
 
 export default class Document extends SvelteComponentTyped<
@@ -14,7 +14,7 @@ export default class Document extends SvelteComponentTyped<
   { change: CustomEvent<any> },
   {
     default: {
-      documents: any;
+      document: any;
       actions: {
         reload: () => Promise<object>;
         update: (data: any) => Promise<object>;

--- a/types/Storage/File.d.ts
+++ b/types/Storage/File.d.ts
@@ -10,6 +10,7 @@ export default class File extends SvelteComponentTyped<
   {},
   {
     default: {
+      file: any;
       actions: {
         download: () => string;
         view: (as?: string) => string;

--- a/types/Storage/FileList.d.ts
+++ b/types/Storage/FileList.d.ts
@@ -28,7 +28,7 @@ export default class FileList extends SvelteComponentTyped<
   {},
   {
     default: {
-      files: any;
+      files: any[];
       actions: {
         reload: () => Promise<object>;
       };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 export { default as Appwrite } from "./Init";
+export { default as SDK } from "./appwrite";
 export { default as User } from "./Account/User";
 export { default as Create } from "./Account/Create";
 export { default as Delete } from "./Account/Delete";


### PR DESCRIPTION
Changes
---
- Added `cache` prop to `Collection` component.
- Added `cache` prop to `Document` component.

Reason for changes
---
These changes are intended to reduce the requests sent to the backend for collections/documents that aren't modified often, increasing responsiveness and decreasing loading times while reducing the load on the backend.

Explanation & Example
---
If the `cache` prop is present on a `Collection` or `Document` component it will check the documents cache each time they are required and request them if they are missing.

Setting the `cache` prop on a `Collection` will enable caching for any child `Document` components.

```html
<Collection {id} let:documents cache>
  {#each documents as document}
    <Document {document}> <!-- equivalent to <Document {document} cache> --> 
      <h1>{document.title}</h1>
      <p>{document.description}</p>
   </Document>
  {/each}
</Collection>
```

