### PR TITLE
Resolve entry for package in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "src",
     "types"
   ],
+  "main": "./types/index.d.ts",
   "types": "./types/index.d.ts",
   "dependencies": {
     "appwrite": "^3.0.1"


### PR DESCRIPTION
Fixed Error:

Failed to resolve entry for package "svelte-appwrite". The package may have incorrect main/module/exports specified in its package.json