### PR TITLE
Update README.md - fixing Collection examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Handle multiple levels of async relational data (and their loading & fallback st
         <h1>Hello {user.name}!</h1>
 
         <!-- 3. 📚 Get all the documents from a collection -->
-        <Collection collection="5f56a3035a01f" let:documents>
+        <Collection id="5f56a3035a01f" let:documents>
             You have {documents.length} documents.
             
             {#each documents as document}
@@ -292,7 +292,7 @@ Get a list of all the documents from a collection.
   import { Collection } from "svelte-appwrite";
 </script>
 
-<Collection collection="5f56a3035a01f" let:documents>
+<Collection id="5f56a3035a01f" let:documents>
   You have {documents.length} documents.
 </Collection>
 ```


### PR DESCRIPTION
Change 'collection' prop to 'id' to resolve the errors:
<Collection> was created with unknown prop 'Collection'
& 
<Collection> was created without expected prop 'id'